### PR TITLE
chore: add unit tests to CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -16,7 +16,7 @@ steps:
 ---
 kind: pipeline
 type: docker
-name: build-test
+name: test
 
 trigger:
   event:
@@ -27,7 +27,7 @@ features:
     enabled: true
 
 steps:
-  - name: build-lint
+  - name: test
     image: golang:1.21-alpine
     commands:
       - apk add --no-cache make bash


### PR DESCRIPTION
Adds CI step for executing unit tests as defined in Makefile
---

- [x] PR title prepended with an exact match of either: `chore: `, `fix: ` or `feat: `

* _chore_: no version bump
* _fix_: patch version bump, non-breaking change which fixes an issue
* _feat_: minor version bump, new feature, non-breaking change which adds functionality
