### PR TITLE
fix: info logs for successful statuses 

### DIFF
--- a/config/samples/gdp_v1alpha1_resourcefieldexport.yaml
+++ b/config/samples/gdp_v1alpha1_resourcefieldexport.yaml
@@ -19,7 +19,7 @@ spec:
   requiredFields:
     statusConditions:
       - type: Ready
-        status: True
+        status: "True"
   outputs:
     - key: host
       path: .status.host

--- a/internal/controller/resourcefieldexport/controller.go
+++ b/internal/controller/resourcefieldexport/controller.go
@@ -110,6 +110,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	if err != nil {
 		return r.degradedStatus(ctx, fieldExports, fmt.Errorf("failed to write to destination: %s", err))
 	}
+	logger.Info(fmt.Sprintf("Successfully written to %s %s", string(fieldExports.Spec.To.Type), fieldExports.Spec.To.Name))
 
 	logger.Info("Operator returned ready status")
 	return r.readyStatus(ctx, fieldExports)

--- a/internal/controller/resourcefieldexport/controller.go
+++ b/internal/controller/resourcefieldexport/controller.go
@@ -60,7 +60,7 @@ type Reconciler struct {
 //+kubebuilder:rbac:groups=storage.cnrm.cloud.google.com,resources=*,verbs=get;list;watch
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	_ = log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	fieldExports := &gdpv1alpha1.ResourceFieldExport{}
 	err := r.Client.Get(ctx, client.ObjectKey{
@@ -111,6 +111,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return r.degradedStatus(ctx, fieldExports, fmt.Errorf("failed to write to destination: %s", err))
 	}
 
+	logger.Info("Operator returned ready status")
 	return r.readyStatus(ctx, fieldExports)
 }
 

--- a/internal/controller/resourcefieldexport/controller.go
+++ b/internal/controller/resourcefieldexport/controller.go
@@ -110,9 +110,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	if err != nil {
 		return r.degradedStatus(ctx, fieldExports, fmt.Errorf("failed to write to destination: %s", err))
 	}
-	logger.Info(fmt.Sprintf("Successfully written to %s %s", string(fieldExports.Spec.To.Type), fieldExports.Spec.To.Name))
+	logger.Info("output written to", "type", fieldExports.Spec.To.Type, "name", fieldExports.Spec.To.Name)
 
-	logger.Info("Operator returned ready status")
 	return r.readyStatus(ctx, fieldExports)
 }
 

--- a/internal/controller/resourcefieldexport/output.go
+++ b/internal/controller/resourcefieldexport/output.go
@@ -5,11 +5,9 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 func (r *Reconciler) writeToSecret(ctx context.Context, name string, namespace string, values map[string]string) error {
-	logger := log.FromContext(ctx)
 	var targetSecret v1.Secret
 	err := r.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, &targetSecret)
 	if err != nil {
@@ -23,15 +21,10 @@ func (r *Reconciler) writeToSecret(ctx context.Context, name string, namespace s
 	for k, v := range values {
 		secretCopy.Data[k] = []byte(v)
 	}
-	err = r.Update(ctx, secretCopy)
-	if err == nil {
-		logger.Info("Values updated successfully in Secret")
-	}
-	return err
+	return r.Update(ctx, secretCopy)
 }
 
 func (r *Reconciler) writeToConfigMap(ctx context.Context, name string, namespace string, values map[string]string) error {
-	logger := log.FromContext(ctx)
 	var targetConfigMap v1.ConfigMap
 	err := r.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, &targetConfigMap)
 	if err != nil {
@@ -45,9 +38,5 @@ func (r *Reconciler) writeToConfigMap(ctx context.Context, name string, namespac
 	for k, v := range values {
 		cmCopy.Data[k] = v
 	}
-	err = r.Update(ctx, cmCopy)
-	if err == nil {
-		logger.Info("Values updated successfully in ConfigMap")
-	}
-	return err
+	return r.Update(ctx, cmCopy)
 }

--- a/internal/controller/resourcefieldexport/output.go
+++ b/internal/controller/resourcefieldexport/output.go
@@ -5,9 +5,11 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 func (r *Reconciler) writeToSecret(ctx context.Context, name string, namespace string, values map[string]string) error {
+	logger := log.FromContext(ctx)
 	var targetSecret v1.Secret
 	err := r.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, &targetSecret)
 	if err != nil {
@@ -21,22 +23,31 @@ func (r *Reconciler) writeToSecret(ctx context.Context, name string, namespace s
 	for k, v := range values {
 		secretCopy.Data[k] = []byte(v)
 	}
-	return r.Update(ctx, secretCopy)
+	err = r.Update(ctx, secretCopy)
+	if err == nil {
+		logger.Info("Values updated successfully in Secret")
+	}
+	return err
 }
 
 func (r *Reconciler) writeToConfigMap(ctx context.Context, name string, namespace string, values map[string]string) error {
-	var targetSecret v1.ConfigMap
-	err := r.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, &targetSecret)
+	logger := log.FromContext(ctx)
+	var targetConfigMap v1.ConfigMap
+	err := r.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, &targetConfigMap)
 	if err != nil {
 		// todo: disambiguate on type of error
 		return err
 	}
-	cmCopy := targetSecret.DeepCopy()
+	cmCopy := targetConfigMap.DeepCopy()
 	if cmCopy.Data == nil {
 		cmCopy.Data = make(map[string]string)
 	}
 	for k, v := range values {
 		cmCopy.Data[k] = v
 	}
-	return r.Update(ctx, cmCopy)
+	err = r.Update(ctx, cmCopy)
+	if err == nil {
+		logger.Info("Values updated successfully in ConfigMap")
+	}
+	return err
 }


### PR DESCRIPTION
Adding info log entry when
1. Exporting resource is in ready status
2. Write the values to secret/configmap is successful. 

---

- [x] PR title prepended with an exact match of either: `chore: `, `fix: ` or `feat: `

* _chore_: no version bump
* _fix_: patch version bump, non-breaking change which fixes an issue
* _feat_: minor version bump, new feature, non-breaking change which adds functionality
