### PR TITLE
fix: fix the sematic release pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -51,7 +51,7 @@ trigger:
 
 steps:
   - name: semantic-release
-    image: node:14.17-alpine
+    image: node:21.3.0-alpine
     environment:
       GITHUB_TOKEN:
         from_secret: GH_READ_TOKEN
@@ -60,8 +60,6 @@ steps:
         apk add git
 
         echo "Overriding default git credentials ..."
-        ## remove credentials
-        rm /root/.netrc
         ## reset committer and author names (populated from the commit metadata where this pipeline is defined on)
         export GIT_COMMITTER_NAME="deliveryhero-bot"
         export GIT_COMMITTER_EMAIL="bot.cicd.ext@deliveryhero.com"


### PR DESCRIPTION
Sematic release pipeline fails because of this error:

```
rm: can't remove '/root/.netrc': No such file or directory
```

---

- [ ] PR title prepended with an exact match of either: `chore: `, `fix: ` or `feat: `

* _chore_: no version bump
* _fix_: patch version bump, non-breaking change which fixes an issue
* _feat_: minor version bump, new feature, non-breaking change which adds functionality
