### PR TITLE
fix: use resource group version from top level

### DIFF
--- a/internal/resourcemanager/resourcemanager.go
+++ b/internal/resourcemanager/resourcemanager.go
@@ -62,13 +62,17 @@ func supportedResources(client PreferredResources) (map[schema.GroupVersionKind]
 	}
 	output := make(map[schema.GroupVersionKind]struct{})
 	for _, resourceList := range preferredResources {
+		gv, err := schema.ParseGroupVersion(resourceList.GroupVersion)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := supportedAPIGroups[gv.Group]; !ok {
+			continue
+		}
 		for _, r := range resourceList.APIResources {
-			if _, ok := supportedAPIGroups[r.Group]; !ok {
-				continue
-			}
 			output[schema.GroupVersionKind{
-				Group:   r.Group,
-				Version: r.Version,
+				Group:   gv.Group,
+				Version: gv.Version,
 				Kind:    r.Kind,
 			}] = struct{}{}
 		}

--- a/internal/resourcemanager/resourcemanager_test.go
+++ b/internal/resourcemanager/resourcemanager_test.go
@@ -62,15 +62,16 @@ type testPreferredResources struct {
 }
 
 func (r *testPreferredResources) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
-	apiResources := make([]metav1.APIResource, 0, len(r.gvks))
+	apiResources := make([]*metav1.APIResourceList, 0, len(r.gvks))
 	for _, gvk := range r.gvks {
-		apiResources = append(apiResources, metav1.APIResource{
-			Group:   gvk.Group,
-			Version: gvk.Version,
-			Kind:    gvk.Kind,
+		apiResources = append(apiResources, &metav1.APIResourceList{
+			GroupVersion: gvk.GroupVersion().Identifier(),
+			APIResources: []metav1.APIResource{
+				{Kind: gvk.Kind},
+			},
 		})
 	}
-	return []*metav1.APIResourceList{{APIResources: apiResources}}, nil
+	return apiResources, nil
 }
 
 func TestRMResources(t *testing.T) {


### PR DESCRIPTION
The Resource Manger calls [ServerPreferredResources](https://pkg.go.dev/k8s.io/client-go/discovery#ServerPreferredResources) to get all the resources which are registered in the control plane. This returns a list of API resources group by the API [GroupVersion](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#APIResourceList). The local E2E tests have a different response to an actual server. In the local E2E test have all the fields populated whereas the actual API server only populates the top-level field.


- [ ] PR title prepended with an exact match of either: `chore: `, `fix: ` or `feat: `

* _chore_: no version bump
* _fix_: patch version bump, non-breaking change which fixes an issue
* _feat_: minor version bump, new feature, non-breaking change which adds functionality
