### PR TITLE
chore: update namespace format to not have leading spaces

### DIFF
--- a/config/crd/bases/gdp.deliveryhero.io_resourcefieldexports.yaml
+++ b/config/crd/bases/gdp.deliveryhero.io_resourcefieldexports.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: resourcefieldexports.gdp.deliveryhero.io
 spec:
   group: gdp.deliveryhero.io
@@ -21,14 +21,19 @@ spec:
           API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object

--- a/internal/controller/resourcefieldexport/controller_test.go
+++ b/internal/controller/resourcefieldexport/controller_test.go
@@ -18,8 +18,9 @@ import (
 	"k8s.io/utils/ptr"
 	cr "sigs.k8s.io/controller-runtime/pkg/client"
 
-	gdpv1alpha1 "github.com/deliveryhero/field-exporter/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	gdpv1alpha1 "github.com/deliveryhero/field-exporter/api/v1alpha1"
 )
 
 var _ = Describe("ResourceFieldExport controller", func() {
@@ -31,7 +32,7 @@ var _ = Describe("ResourceFieldExport controller", func() {
 		ctx := context.Background()
 
 		// generate randomized test namespace name
-		testNamespace = fmt.Sprintf("test-%3d", rand.Intn(10000))
+		testNamespace = fmt.Sprintf("test-%03d", rand.Intn(10000))
 		// create the test namespace
 		namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNamespace}}
 		Expect(k8sClient.Create(ctx, namespace)).Should(Succeed())


### PR DESCRIPTION
The current formatting directive `%3d` will create strings of type `test- 15` if the random number happens to be in the range `0-99` making it `%03d` ensures padding with leading zeros instead of spaces

---

- [X] PR title prepended with an exact match of either: `chore: `, `fix: ` or `feat: `

* _chore_: no version bump
* _fix_: patch version bump, non-breaking change which fixes an issue
* _feat_: minor version bump, new feature, non-breaking change which adds functionality
