### PR TITLE
chore: update drone pipeline to use go 1.22

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -28,7 +28,7 @@ features:
 
 steps:
   - name: test
-    image: golang:1.21-alpine
+    image: golang:1.22-alpine
     commands:
       - apk add --no-cache make bash
       - make test


### PR DESCRIPTION
Updates drone pipeline to use go 1.22 to satisfy dependency requirements
---

- [x] PR title prepended with an exact match of either: `chore: `, `fix: ` or `feat: `

* _chore_: no version bump
* _fix_: patch version bump, non-breaking change which fixes an issue
* _feat_: minor version bump, new feature, non-breaking change which adds functionality
